### PR TITLE
Fix rare panics at teardown

### DIFF
--- a/service/pinger/pinger_test.go
+++ b/service/pinger/pinger_test.go
@@ -27,11 +27,10 @@ func server(ctx context.Context) (pb.PingerClient, func()) {
 
 	conn, _ := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
-	}), grpc.WithInsecure())
+	}), grpc.WithInsecure(), grpc.WithBlock())
 
 	closer := func() {
 		s.Stop()
-		listener.Close()
 	}
 
 	client := pb.NewPingerClient(conn)

--- a/service/pinger/pinger_test.go
+++ b/service/pinger/pinger_test.go
@@ -28,14 +28,9 @@ func server(ctx context.Context) (pb.PingerClient, func()) {
 	conn, _ := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return listener.Dial()
 	}), grpc.WithInsecure(), grpc.WithBlock())
-
-	closer := func() {
-		s.Stop()
-	}
-
 	client := pb.NewPingerClient(conn)
 
-	return client, closer
+	return client, s.Stop
 }
 
 func TestPinger(t *testing.T) {

--- a/service/pinger/pinger_test.go
+++ b/service/pinger/pinger_test.go
@@ -30,8 +30,8 @@ func server(ctx context.Context) (pb.PingerClient, func()) {
 	}), grpc.WithInsecure())
 
 	closer := func() {
-		listener.Close()
 		s.Stop()
+		listener.Close()
 	}
 
 	client := pb.NewPingerClient(conn)

--- a/service/pinger/pinger_test.go
+++ b/service/pinger/pinger_test.go
@@ -133,3 +133,8 @@ func TestPingerStream(t *testing.T) {
 		})
 	}
 }
+
+func TestNoRPCs(t *testing.T) {
+	_, closer := server(context.Background())
+	defer closer()
+}


### PR DESCRIPTION
Hello! This patch fixes two race conditions which cause occasional panics at shutdown. The problems are rare in practice, but can be reliably reproduced with the race detector by running:

```console
$ go test -race -count=1000 ./...
(snip irrelevant output)
panic: closed
goroutine 13371 [running]:
github.com/davidharrigan/bufconn-test/service/pinger.server.func1()
        /Users/adammck/code/src/github.com/adammck/bufconn-test/service/pinger/pinger_test.go:24 +0x67
created by github.com/davidharrigan/bufconn-test/service/pinger.server
        /Users/adammck/code/src/github.com/adammck/bufconn-test/service/pinger/pinger_test.go:22 +0x26a
FAIL    github.com/davidharrigan/bufconn-test/service/pinger    2.781s
FAIL
```

This is happening because there is currently no synchronization preventing `Listener.Close` being called (by the closer) before `Listener.Accept` is called (by `Server.Serve`, in the goroutine) -- which is of course invalid, and leads to a panic.

We can mitigate this somewhat by swapping the order of Stop and Close (as I did in the first commit to this branch), since Stop performs some synchronization which makes this impossible so long as Dial has completed, which will happen so long as any blocking RPC is sent in the test. And as it happens, we don't have to swap them, because calling Stop [calls Close on the listener](https://github.com/grpc/grpc-go/blob/7567a5d96538a01715827a3eba57e70d8eedec37/server.go#L1725), so I removed it from the test helper.

That mostly solves the problem in practice, but in tests which Dial may not have completed (i.e. tests which don't send any RPCs), it instead manifests as:

```console
$ go test -race -count=1000 ./...
(snip irrelevant output)
panic: grpc: the server has been stopped
```

This is the same problem as above; we're (rarely) calling `Server.Stop` before `Server.Serve` because no blocking RPC is there to synchronize the two goroutines. This is admittedly a weird thing to do, but shouldn't cause panics. So I added a test to verify that.

Anyway, we can avoid this whole problem by making the dial [blocking](https://pkg.go.dev/google.golang.org/grpc#WithBlock), so by the time we return from `server` it is definitely safe to call the closer. This is sub-optimal for those tests which don't send any RPCs, so there's no reason to wait, but I think keeping the helper simple is more desirable than handling that edge-case with a conditional Stop.

----

More importantly than this repo, I would suggest updating the blog post at:
https://harrigan.xyz/blog/testing-go-grpc-server-using-an-in-memory-buffer-with-bufconn/
which is one of the top search results for this sort of thing. (Thank you for writing that up, by the way -- I use it all the time, which is how I stumbled upon this problem.)